### PR TITLE
Import fixes for python 3.x

### DIFF
--- a/fred/__init__.py
+++ b/fred/__init__.py
@@ -1,1 +1,4 @@
-from api import *
+try:
+	from .api import *
+except ImportError:
+	from api import *

--- a/fred/core.py
+++ b/fred/core.py
@@ -5,7 +5,10 @@ Core functionality for interacting with the FRED API.
 """
 
 import os
-from itertools import ifilter
+try:
+	from itertools import ifilter as filter
+except ImportError:
+	pass
 
 import requests
 from relaxml import xml
@@ -24,7 +27,7 @@ class Fred(object):
 
     def _create_path(self, *args):
         """Create the URL path with the Fred endpoint and given arguments."""
-        args = ifilter(None, args)
+        args = filter(None, args)
         path = self.endpoint + '/'.join(args)
         return path
 


### PR DESCRIPTION
Update imports so they also work in Python 3.x. Tested with Python 3.3.0 & 2.6.5.
